### PR TITLE
tweak current svg

### DIFF
--- a/data/templates/profile/de/document.svg
+++ b/data/templates/profile/de/document.svg
@@ -60,7 +60,7 @@
     	S201.18,1103.71,278.51,760.3S696.92,201.18,1040.33,278.51z"/>
     <text>
       <textPath xlink:href="#SVGID_x5F_1_x5F_" startOffset="98.1487%">
-        <tspan class="st3" style="fill: #90D3ED; font-family:'Jost-Bold'; font-size:236px; letter-spacing:46;">29. NOVEMBER</tspan>
+        <tspan class="st3" style="fill: #90D3ED; font-family:'Jost-Bold'; font-size:236px; letter-spacing:46;">{{ date }}</tspan>
       </textPath>
     </text>
 
@@ -70,7 +70,7 @@
       <text style="font-family: 'Jost-700'; font-size: 230px; fill: #90D3ED; letter-spacing: 40px;">
         <textPath xlink:href="#circle1" style="alignment-baseline: hanging;">
           <tspan x="0" dy="210">
-            29. NOVEMBER
+            {{ date }}
           </tspan>
         </textPath>
       </text>
@@ -85,12 +85,24 @@
 
     <g>
       <path d="M 0,1217 l 680,0 65,165 l 615,0 0,228 -1800,0" style="fill: #EF454E;" clip-path="url(#circle-outer)"/>
-      <text transform="matrix(1 0 0 1 177.0304 1338.5349)" x="-20px" y="40" class="st3 st4 st5 st6 subtitle">KLIMA</text>
-      <text transform="matrix(1 0 0 1 436.5146 1516.5264)" y="40" class="st3 st4 st5 st6 subtitle">STREIK</text>
+      <text
+        transform="matrix(1 0 0 1 177.0304 1338.5349)"
+        x="-20px"
+        y="40"
+        class="st3 st4 st5 st6 subtitle"
+        v-bind:style="[(lang === 'de') ? {} : {'letter-spacing': '0', 'font-size': '140px',}]">{{ first }}</text>
+      <text
+        transform="matrix(1 0 0 1 436.5146 1516.5264)"
+        y="40"
+        class="st3 st4 st5 st6 subtitle"
+        v-bind:style="[(lang === 'de') ? {} : {'letter-spacing': '0', 'font-size': '140px',}]">{{ second }}</text>
     </g>
 
     <path class="st2" d="M163,1409"/>
-    <text x="900" y="1720" style="text-anchor: middle; alignment-baseline: bottom; font-size: 100px; font-family: 'Jost-400'; fill: #90D3ED;" y="60" class="st3 st7 st8">
+    <text
+      x="900"
+      y="1720"
+      v-bind:style="[(lang === 'de') ? {'text-anchor': 'middle', 'alignment-baseline': 'bottom', 'font-size': '100px', 'font-family': 'Jost-400', 'fill': '#90D3ED'} : {'text-anchor': 'middle', 'alignment-baseline': 'bottom', 'font-size': '75px', 'font-family': 'Jost-400', 'fill': '#90D3ED'}]">
       {{ hashtag }}
     </text>
   </g>

--- a/data/templates/profile/de/template.json
+++ b/data/templates/profile/de/template.json
@@ -51,6 +51,42 @@
       "properties": {
 
       }
+    },
+    {
+      "type": "Line",
+      "description": "Langugage",
+      "key": "lang",
+      "default": "de",
+      "properties": {
+
+      }
+    },
+    {
+      "type": "Line",
+      "description": "Date",
+      "key": "date",
+      "default": "29. NOVEMBER",
+      "properties": {
+
+      }
+    },
+    {
+      "type": "Line",
+      "description": "First Red",
+      "key": "first",
+      "default": "KLIMA",
+      "properties": {
+
+      }
+    },
+    {
+      "type": "Line",
+      "description": "Second Red",
+      "key": "second",
+      "default": "STREIK",
+      "properties": {
+
+      }
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
 
     <link rel="stylesheet" href="css/master.css">
-    <script src="js/app.js" charset="utf-8" type="module"></script>
+    <script src="/js/app.js" charset="utf-8" type="module"></script>
 
 
   </head>
@@ -26,7 +26,7 @@
       <div class="menu-bar" v-bind:class="{ 'menu-open': menuOpen }">
         <div class="bar-top">
           <div class="info">
-            <img src="data/resources/compass.svg" alt="Toolpic" class="emblem">
+            <img src="/data/resources/compass.svg" alt="Toolpic" class="emblem">
           </div>
           <div class="btns">
             <div class="copyright-text">
@@ -125,7 +125,7 @@
             <div v-if="!renderedImage" class="spinner">
               <div class="fff-spinner">
                 <div class="inner-circle">
-                  <img src="data/resources/logo-new-spinner.svg" alt="#FFF">
+                  <img src="/data/resources/logo-new-spinner.svg" alt="#FFF">
                 </div>
               </div>
               <!--<div class="sk-cube-grid">


### PR DESCRIPTION
add some more dimensions to enable multi lang support on curent svg image.
It works nice for the preview, but does not work for the export. it seams the new values are ingnored in the template for the download.

Just change:
date: 2019-11-29
language: en
first-red: CLIMATE
second-red: STRIKE
hashtag: #UniteBehindTheScience
i added a simple condition on `language` to decrease some font-size values, cause the other translations are longer then in german